### PR TITLE
Fix mixcons build setup

### DIFF
--- a/mixcons/mixcons.cpp
+++ b/mixcons/mixcons.cpp
@@ -1,7 +1,40 @@
-﻿#include "mix_file.h"
+#include "mix_file.h"
 #include "shp_ts_file.h"
 #include "pal_file.h"
+#include "palet.h"
+#include "shp_decode.h"
+#include "png_file.h"
 #include <filesystem>
+#include <cstring>
+#include <boost/algorithm/string.hpp>
+
+static Cvirtual_image decode_frame32(const Cshp_ts_file& shp, int frame, const t_palet pal)
+{
+    int global_cx = shp.cx();
+    int global_cy = shp.cy();
+    int cx = shp.get_cx(frame);
+    int cy = shp.get_cy(frame);
+    Cvirtual_binary frame;
+    if (shp.is_compressed(frame))
+        decode3(shp.get_image(frame), frame.write_start(cx * cy), cx, cy);
+    else
+        frame = Cvirtual_binary(shp.get_image(frame), cx * cy);
+
+    Cvirtual_binary canvas;
+    std::memset(canvas.write_start(global_cx * global_cy), 0, global_cx * global_cy);
+    byte* w = canvas.data_edit() + shp.get_x(frame) + global_cx * shp.get_y(frame);
+    const byte* r = frame.data();
+    for (int y = 0; y < cy; ++y)
+    {
+        std::memcpy(w, r, cx);
+        r += cx;
+        w += global_cx;
+    }
+
+    Cvirtual_binary rgba;
+    upsample_image(canvas.data(), reinterpret_cast<t_palet32entry*>(rgba.write_start(global_cx * global_cy * sizeof(t_palet32entry))), global_cx, global_cy, pal);
+    return Cvirtual_image(rgba, global_cx, global_cy, 4, nullptr);
+}
 
 int wmain(int argc, wchar_t* argv[])
 {
@@ -10,24 +43,25 @@ int wmain(int argc, wchar_t* argv[])
         return 1;
     }
     std::filesystem::path mixPath = argv[1];
-    palette pal;  pal.load(argv[2]);
+    Cpal_file pal_f; pal_f.open(argv[2]);
+    t_palet pal; pal_f.decode(pal);
 
-    mix_file mix; mix.open(mixPath.string().c_str());
+    Cmix_file mix; mix.open(mixPath.string().c_str());
 
     for (int i = 0; i < mix.get_c_files(); ++i) {
-        std::string name = mix.get_name(i);
-        mem_block buf;  mix.extract(i, buf);
+        int id = mix.get_id(i);
+        std::string name = mix.get_name(id);
+        Cvirtual_binary buf = mix.get_vdata(id);
 
         if (boost::iends_with(name, ".shp")) {
-            shp_ts_file shp;  shp.open(buf);
-            for (int f = 0; f < shp.get_c_frames(); ++f) {
-                auto img = shp.decode_frame32(f, pal);
+            Cshp_ts_file shp;  shp.load(buf);
+            for (int f = 0; f < shp.cf(); ++f) {
+                auto img = decode_frame32(shp, f, pal);
                 std::string out = name + "_" + std::to_string(f) + ".png";
-                image_file::write_png(out.c_str(), img);
+                img.save(out, ft_png);
             }
-        }
-        else {
-            write_file(name, buf);
+        } else {
+            buf.save(name);
         }
     }
     return 0;

--- a/mixcons/virtual_binary.h
+++ b/mixcons/virtual_binary.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <string>
 #include <vartypes.h>
-#include <xcc/data_ref.h>
+#include "data_ref.h"
 
 using namespace std;
 


### PR DESCRIPTION
## Summary
- fix include path for `virtual_binary.h`
- implement standalone SHP decoding helper
- rework CLI to load palette and use library extractors

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -I mixcons -I /usr/x86_64-w64-mingw32/include -c mixcons/mixcons.cpp -o mixcons/mixcons.o` *(fails: boost/algorithm/string.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687006cfaa988325997777202c73ea46