### PR TITLE
Автосборка при запуске Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ WORKDIR /project
 # Папки, куда можно монтировать дополнительные пакеты
 VOLUME ["/build_packages", "/vcpkg_packages"]
 
-CMD ["bash"]
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,9 @@ services:
       - ./:/project
       - build_packages:/build_packages:ro
       - vcpkg_packages:/vcpkg_packages
+    environment:
+      - VERSION=1.0.0
     working_dir: /project
-    tty: true
 volumes:
   build_packages:
   vcpkg_packages:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+VERSION="${VERSION:-dev}"
+BUILD_DIR="/project/build"
+RELEASE_DIR="/project/releases/${VERSION}"
+mkdir -p "$BUILD_DIR" "$RELEASE_DIR"
+cd /project
+cmake -S . -B "$BUILD_DIR" -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build "$BUILD_DIR" --config Release
+# copy resulting binary
+if [ -f "$BUILD_DIR/mixcons.exe" ]; then
+  cp "$BUILD_DIR/mixcons.exe" "$RELEASE_DIR/"
+elif [ -f "$BUILD_DIR/mixcons" ]; then
+  cp "$BUILD_DIR/mixcons" "$RELEASE_DIR/"
+fi


### PR DESCRIPTION
## Summary
- add entrypoint script for automated build
- use the new script from Dockerfile
- run build automatically via docker-compose and store result in `releases/$VERSION`

## Testing
- `./docker-entrypoint.sh` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68713c078b5c8325bea0905a844963ce